### PR TITLE
fixed CodeUri of Lambda function to reference the generated function.zip

### DIFF
--- a/image-resize.yaml
+++ b/image-resize.yaml
@@ -30,7 +30,7 @@ Resources:
   ResizeFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./lambda
+      CodeUri: ./dist/function.zip
       Handler: index.handler
       Runtime: nodejs4.3
       MemorySize: 1536


### PR DESCRIPTION
I'm on windows and cannot directly use the `node_modules` folder by using a host volume. So I wondered why I couldn't get the example working. After trying out I found out that you don't specify the `function.zip` which was actually built for this.
So I think it would be best for all the windows guys (and all Lambda newbies) to use the zip from `make dist`