### PR TITLE
Update npm to latest version in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN yum -y groupinstall "Development Tools" && \
     curl --location --output ns.rpm https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.3.2-1nodesource.el7.centos.x86_64.rpm && \
     rpm --checksig ns.rpm && \
     rpm --install --force ns.rpm && \
+    npm install -g npm@latest && \
+    npm cache clean && \
     rm --force ns.rpm
 
 VOLUME /build


### PR DESCRIPTION
For me, the docker method of creating the function zip hangs during the `npm install --production` phase. I solved it by updating the npm tool to the latest version in the docker image.