### PR TITLE
Fixed old files remaining in function.zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ package: image
 	docker run --rm --volume ${PWD}/lambda:/build amazonlinux:nodejs npm install --production
 
 dist: package
-	cd lambda && zip -r ../dist/function.zip *
+	cd lambda && zip -FS -q -r ../dist/function.zip *
 
 clean:
 	rm -r lambda/node_modules


### PR DESCRIPTION
By default the `zip` command adds and updates files to existing archives but doesn't delete files that are in the zip file but not on the file system. Adding the command line switch `-FS` (filesync) makes sure that the zip file doesn't contain obsolete files after, for instance, an npm module update.

I also added the `-q` switch to make the output less verbose.