### PR TITLE
Only install necessary packages via yum, cleanup yum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ ADD etc/nodesource.gpg.key /etc
 
 WORKDIR /tmp
 
-RUN yum -y groupinstall "Development Tools" && \
+RUN yum -y install gcc-c++ && \
     rpm --import /etc/nodesource.gpg.key && \
     curl --location --output ns.rpm https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.3.2-1nodesource.el7.centos.x86_64.rpm && \
     rpm --checksig ns.rpm && \
     rpm --install --force ns.rpm && \
     npm install -g npm@latest && \
     npm cache clean && \
+    yum clean all && \
     rm --force ns.rpm
 
 VOLUME /build


### PR DESCRIPTION
It could be considered nitpicking, but I thought it was a waste of time and disk resources to install the entire development group of yum packages. I assumed it would take me a while before I found all necessary packages via trial and error, but to my surprise only `gcc-c++` is needed to build sharp.

This saves quite some time building the function using docker.