### PR TITLE
better windows compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ ADD etc/nodesource.gpg.key /etc
 
 WORKDIR /tmp
 
-RUN yum -y install gcc-c++ \
+RUN yum -y aws-cli \ 
         findutils \
-		zip \
-		aws-cli && \
+        gcc-c++ \
+        zip && \
     rpm --import /etc/nodesource.gpg.key && \
     curl --location --output ns.rpm https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.3.2-1nodesource.el7.centos.x86_64.rpm && \
     rpm --checksig ns.rpm && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD etc/nodesource.gpg.key /etc
 
 WORKDIR /tmp
 
-RUN yum -y aws-cli \ 
+RUN yum -y install aws-cli \ 
         findutils \
         gcc-c++ \
         zip && \
@@ -17,3 +17,4 @@ RUN yum -y aws-cli \
     yum clean all && \
     rm --force ns.rpm
 
+WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ ADD etc/nodesource.gpg.key /etc
 
 WORKDIR /tmp
 
-RUN yum -y install gcc-c++ && \
+RUN yum -y install gcc-c++ \
+        findutils \
+		zip \
+		aws-cli && \
     rpm --import /etc/nodesource.gpg.key && \
     curl --location --output ns.rpm https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.3.2-1nodesource.el7.centos.x86_64.rpm && \
     rpm --checksig ns.rpm && \
@@ -13,6 +16,8 @@ RUN yum -y install gcc-c++ && \
     npm cache clean && \
     yum clean all && \
     rm --force ns.rpm
+
+RUN echo complete -C '/usr/bin/aws_completer' aws >> /root/.bashrc
 
 VOLUME /build
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The complete setup can be done with Docker. Therefore you only need to [install]
 
   The deployment script requires the [AWS CLI][cli] version 1.11.19 or newer to be installed. This is brought to you by using the previously built Docker image. You need to have you AWS configuration in a folder `.aws` next to this project dir. As first time user you have to run `make awsconfigure`.
 
-  Run `make deploy` to deploy the CloudFormation stack. It will create a temporary Amazon S3 bucket, package and upload the function, and create the Lambda function, Amazon API Gateway RestApi, and an S3 bucket for images via CloudFormation.
+  Run `make deploy` to deploy the CloudFormation stack. It will create a temporary Amazon S3 bucket, package and upload the function, and create the Lambda function, Amazon API Gateway REST API, and an S3 bucket for images via CloudFormation.
 
-  Please be aware that you might prefix the _deploy_ target in the _Makefile_ with `winpty` depending on your environment under windows!
+  Please be aware that you might prefix the _deploy_ target in the _Makefile_ with `winpty` depending on your environment under Windows!
 
 1. Test the function
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Resizes images on the fly using Amazon S3, AWS Lambda, and Amazon API Gateway. U
 
 ## Usage
 
+The complete setup can be done with Docker. Therefore you only need to [install][docker] it.
+
 1. Build the Lambda function
 
    The Lambda function uses [sharp][sharp] for image resizing which requires native extensions. In order to run on Lambda, it must be packaged on Amazon Linux. You can accomplish this in one of two ways:
@@ -16,9 +18,11 @@ Resizes images on the fly using Amazon S3, AWS Lambda, and Amazon API Gateway. U
 
 1. Deploy the CloudFormation stack
 
-  Run `bin/deploy` to deploy the CloudFormation stack. It will create a temporary Amazon S3 bucket, package and upload the function, and create the Lambda function, Amazon API Gateway RestApi, and an S3 bucket for images via CloudFormation.
+  The deployment script requires the [AWS CLI][cli] version 1.11.19 or newer to be installed. This is brought to you by using the previously built Docker image. You need to have you AWS configuration in a folder `.aws` next to this project dir. As first time user you have to run `make awsconfigure`.
 
-  The deployment script requires the [AWS CLI][cli] version 1.11.19 or newer to be installed.
+  Run `make deploy` to deploy the CloudFormation stack. It will create a temporary Amazon S3 bucket, package and upload the function, and create the Lambda function, Amazon API Gateway RestApi, and an S3 bucket for images via CloudFormation.
+
+  Please be aware that you might prefix the _deploy_ target in the _Makefile_ with `winpty` depending on your environment under windows!
 
 1. Test the function
 
@@ -38,3 +42,4 @@ This reference architecture sample is [licensed][license] under Apache 2.0.
 [sharp]: https://github.com/lovell/sharp
 [amazon-linux]: https://aws.amazon.com/blogs/compute/nodejs-packages-in-lambda/
 [cli]: https://aws.amazon.com/cli/
+[docker]: https://www.docker.com/products/docker


### PR DESCRIPTION
because windows is "special" there are a lot problems arising when installing nodejs modules. Because of lots of symlinks you cannot mount the host directory directly. Therefore the *node_modules* directory is a volume in the Docker container. I am aware this means you cannot access all files inside directly. But I think as a quick example to be easily setup this is the way to go.
I also added _aws-cli_ to the image so you easily can deploy everything without installing anything else then Docker.

But I also can understand if you don't want to go with these changes.