### PR TITLE
Use Node.js 6.10 runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp
 
 RUN yum -y install gcc-c++ && \
     rpm --import /etc/nodesource.gpg.key && \
-    curl --location --output ns.rpm https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodejs-4.3.2-1nodesource.el7.centos.x86_64.rpm && \
+    curl --location --output ns.rpm https://rpm.nodesource.com/pub_6.x/el/7/x86_64/nodejs-6.10.1-1nodesource.el7.centos.x86_64.rpm && \
     rpm --checksig ns.rpm && \
     rpm --install --force ns.rpm && \
     npm install -g npm@latest && \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Resizes images on the fly using Amazon S3, AWS Lambda, and Amazon API Gateway. U
 
 	You can find the BucketWebsiteUrl in the table of outputs displayed on a successful invocation of the deploy script.
 
-**Note:** If you create the Lambda function yourself, make sure to select Node.js version 4.3.
+**Note:** If you create the Lambda function yourself, make sure to select Node.js version 6.10.
 
 ## License
 

--- a/image-resize.yaml
+++ b/image-resize.yaml
@@ -32,7 +32,7 @@ Resources:
     Properties:
       CodeUri: ./dist/function.zip
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs6.10
       MemorySize: 1536
       Timeout: 60
       Environment:

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -7,9 +7,9 @@
   "license": "Apache-2.0",
   "main": "index.js",
   "dependencies": {
-    "sharp": "^0.16.0"
+    "sharp": "^0.17.3"
   },
   "devDependencies": {
-    "aws-sdk": "^2.6.9"
+    "aws-sdk": "^2.36.0"
   }
 }


### PR DESCRIPTION
This PR updates the Node.js version used to build function.zip to 6.10 and makes it compatible with the new Node.js version offered by Amazon. The NPM packages are also updated to their latest versions.