### PR TITLE
Docker make all fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN yum -y install gcc-c++ && \
     rpm --checksig ns.rpm && \
     rpm --install --force ns.rpm && \
     npm install -g npm@latest && \
-    npm cache clean && \
+    npm cache clean --force && \
     yum clean all && \
     rm --force ns.rpm
 


### PR DESCRIPTION
Works for me after applying the fix from here:
https://github.com/nodejs/docker-node/pull/426/files

**The docker make all error message:**

npm ERR! As of npm@5, the npm cache self-heals from corruption issues and data extracted from the cache is guaranteed to be valid. If you want to make sure everything is consistent, use 'npm cache verify' instead.
npm ERR!
npm ERR! If you're sure you want to delete the entire cache, rerun this command with --force.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2017-06-12T18_41_15_467Z-debug.log
The command '/bin/sh -c yum -y install gcc-c++ &&     rpm --import /etc/nodesource.gpg.key &&     curl --location --output ns.rpm https://rpm.nodesource.com/pub_6.x/el/7/x86_64/nodejs-6.10.1-1nodesource.el7.centos.x86_64.rpm &&     rpm --checksig ns.rpm &&     rpm --install --force ns.rpm &&     npm install -g npm@latest &&     npm cache clean &&     yum clean all &&     rm --force ns.rpm' returned a non-zero code: 1
make: *** [image] Error 1

**After fix:**

make: Leaving directory `/build/node_modules/sharp/build'
npm notice created a lockfile as package-lock.json. You should commit this file.
added 49 packages in 36.607s