### PR TITLE
Decode the key parameter to handle complex keys

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -10,7 +10,7 @@ const BUCKET = process.env.BUCKET;
 const URL = process.env.URL;
 
 exports.handler = function(event, context, callback) {
-  const key = event.queryStringParameters.key;
+  const key = decodeURIComponent(event.queryStringParameters.key);
   const match = key.match(/(\d+)x(\d+)\/(.*)/);
   const width = parseInt(match[1], 10);
   const height = parseInt(match[2], 10);


### PR DESCRIPTION
If the file uploaded is for example `foo bär's.jpg`, this function will fail since they key it will be looking for is going to be in URI encoded format.

Decoding the key at the beginning of function will fix this.