### PR TITLE
Remove carriage returns in account_id

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -6,7 +6,7 @@ stack_name=ServerlessImageResize
 region="$(aws configure get region)"
 bucket_name="temp-serverless-resize-$(openssl rand -hex 8)"
 account_id="$(aws sts get-caller-identity --query Account --output text \
-  | xargs echo -n)"
+  | xargs echo -n | tr -d '\r')"
 
 set -o xtrace
 


### PR DESCRIPTION
When run from a mingw bash on Windows, a dangling carriage return caused deployment problems. This removes that possibility