### PR TITLE
Redirect code is now a configurable value.

### DIFF
--- a/lambda/index.js
+++ b/lambda/index.js
@@ -8,6 +8,7 @@ const Sharp = require('sharp');
 
 const BUCKET = process.env.BUCKET;
 const URL = process.env.URL;
+const REDIRECT_CODE = process.env.REDIRECT_CODE || '301';
 const ALLOWED_DIMENSIONS = new Set();
 
 if (process.env.ALLOWED_DIMENSIONS) {
@@ -46,7 +47,7 @@ exports.handler = function(event, context, callback) {
       }).promise()
     )
     .then(() => callback(null, {
-        statusCode: '301',
+        statusCode: REDIRECT_CODE,
         headers: {'location': `${URL}/${key}`},
         body: '',
       })


### PR DESCRIPTION
Set the `REDIRECT_CODE` environment variable in Lambda to control the code. Defaults to `301`.

CloudFront [does not follow 301 or 307 redirect codes](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/http-3xx-status-codes.html). In order to use CloudFront with this image resizing system, we need to be able to adjust the redirect code it uses to return to the S3 bucket.