### PR TITLE
install required `make` package in docker container before building npm package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ image:
 	docker build --tag amazonlinux:nodejs .
 
 package: image
-	docker run --rm --volume ${PWD}/lambda:/build amazonlinux:nodejs npm install --production
+	docker run --rm --volume ${PWD}/lambda:/build amazonlinux:nodejs bash -c "yum install -y make && npm install --production"
 
 dist: package
 	cd lambda && zip -FS -q -r ../dist/function.zip *


### PR DESCRIPTION
`make package` fails with 

```
docker run --rm --volume /Users/grav/repo/serverless-image-resizing/lambda:/build amazonlinux:nodejs npm install --production

> sharp@0.17.3 install /build/node_modules/sharp
> node-gyp rebuild

gyp ERR! build error 
gyp ERR! stack Error: not found: make
```

This PR installs `make` via yum on the Amazon Linux docker container before installing the sharp npm package.